### PR TITLE
🐳 多架构 Docker 镜像

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>pulic-mirror</id>
+            <mirrorOf>public</mirrorOf>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </mirror>
+    </mirrors>
+    <profiles>
+        <profile>
+            <id>h-repos</id>
+            <repositories>
+                <repository>
+                    <id>centra</id>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Maven Central Plugin Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>h-repos</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,153 @@
+name: Docker
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+permissions: # This is needed to push to GitHub Container Registry. See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+  contents: read
+  packages: write
+concurrency: # This is needed to prevent concurrent builds from running at the same time
+  group: ${{github.workflow}} - ${{github.ref}} - ${{github.ref_name}}
+  cancel-in-progress: true
+env:
+  # https://github.com/docker/metadata-action/tree/v5/?tab=readme-ov-file#semver
+  # Event: push,     Ref: refs/head/main,       Tags: main
+  # Event: push tag, Ref: refs/tags/v1.2.3,     Tags: 1.2.3, 1.2, 1, latest
+  # Event: push tag, Ref: refs/tags/v2.0.8-rc1, Tags: 2.0.8-rc1
+  metadata-action-tags: |
+    type=ref,event=branch
+    type=semver,pattern={{version}}
+    type=semver,pattern={{major}}.{{minor}}
+    type=semver,pattern={{major}}
+jobs:
+  build-service:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 检出代码
+        uses: actions/checkout@main
+      - name: ☕ 配置Java环境
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: maven
+      - name: 🛠️ 配置Maven环境
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+      - name: 🏗️ Maven构建
+        run: |
+          mvn --batch-mode clean install -Dmaven.test.skip=true --threads=1C --settings=.github/settings.xml
+          #  -Dspring.profiles.active=prod
+      - name: 🔑 登录 GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏷️ 准备 Docker 镜像元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-service
+          tags: ${{ env.metadata-action-tags }}
+      - name: 🖥️ 设置 QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: 🐳 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: 🚀 构建并推送 Docker 镜像
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          push: true
+          file: docker-multiarch/Dockerfile.service
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+  build-mysql:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 检出代码
+        uses: actions/checkout@main
+      - name: 🔑 登录 GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏷️ 准备 Docker 镜像元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-mysql
+          tags: ${{ env.metadata-action-tags }}
+      - name: 🖥️ 设置 QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: 🐳 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: 🚀 构建并推送 Docker 镜像
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          push: true
+          file: docker-multiarch/Dockerfile.mysql
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+  build-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 检出代码
+        uses: actions/checkout@main
+      - name: 📦 安装 PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - name: 🟢 设置 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: 'orion-visor-ui/pnpm-lock.yaml'
+      - name: 📥 安装依赖
+        run: pnpm install --frozen-lockfile
+        working-directory: orion-visor-ui
+      - name: 🏗️ 构建UI
+        run: pnpm build
+        working-directory: orion-visor-ui
+      - name: 🔑 登录 GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏷️ 准备 Docker 镜像元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}-ui
+          tags: ${{ env.metadata-action-tags }}
+      - name: 🖥️ 设置 QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: 🐳 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: 🚀 构建并推送 Docker 镜像
+        uses: docker/build-push-action@v6
+        with:
+          context: '.'
+          push: true
+          file: docker-multiarch/Dockerfile.ui
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.multiarch.yml
+++ b/docker-compose.multiarch.yml
@@ -1,0 +1,76 @@
+services:
+  ui:
+    depends_on:
+      - service
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: docker-multiarch/Dockerfile.ui
+    # environment:
+    #   CADDY_TRUSTED_PROXIES: |-
+    #     192.168.1.1
+    ports:
+      - ${SERVICE_PORT:-1081}:80
+    image: ghcr.io/dromara/orion-visor-ui:2
+  service:
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: docker-multiarch/Dockerfile.service
+    environment:
+      MYSQL_HOST: ${MYSQL_HOST:-mysql}
+      MYSQL_PORT: ${MYSQL_PORT:-3306}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-orion_visor}
+      MYSQL_USER: ${MYSQL_USER:-orion}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-Data@123456}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-Data@123456}
+      SECRET_KEY: ${SECRET_KEY:-uQeacXV8b3isvKLK}
+      DEMO_MODE: ${DEMO_MODE:-false}
+    volumes:
+      - ${VOLUME_BASE:-/data/orion-visor-space/docker-volumes}/service/root-orion:/root/orion
+    image: ghcr.io/dromara/orion-visor-service:2
+  mysql:
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: docker-multiarch/Dockerfile.mysql
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-orion_visor}
+      MYSQL_USER: ${MYSQL_USER:-orion}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-Data@123456}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-Data@123456}
+    volumes:
+      - ${VOLUME_BASE:-/data/orion-visor-space/docker-volumes}/mysql/var-lib-mysql:/var/lib/mysql
+    image: ghcr.io/dromara/orion-visor-mysql:2
+  redis:
+    restart: unless-stopped
+    environment:
+      - TZ=Asia/Shanghai
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-Data@123456}
+    volumes:
+      - ${VOLUME_BASE:-/data/orion-visor-space/docker-volumes}/redis/data:/data
+    command: sh -c "redis-server --requirepass $${REDIS_PASSWORD}"
+    healthcheck:
+      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+      start_interval: 1s
+    image: redis:7-alpine
+  adminer:
+    depends_on:
+      mysql:
+        condition: service_healthy
+    ports:
+      - 8081:8080
+    environment:
+      - ADMINER_DEFAULT_SERVER=${MYSQL_HOST:-mysql}
+    image: adminer:latest

--- a/docker-multiarch/Caddyfile
+++ b/docker-multiarch/Caddyfile
@@ -1,0 +1,19 @@
+{
+	servers {
+		trusted_proxies static {$CADDY_TRUSTED_PROXIES}
+	}
+}
+
+:80 {
+	@api {
+		path /orion-visor/*
+	}
+	handle @api {
+		reverse_proxy http://service:9200
+	}
+	handle {
+		root * /usr/share/caddy
+		try_files {path} /index.html
+		file_server
+	}
+}

--- a/docker-multiarch/Dockerfile.mysql
+++ b/docker-multiarch/Dockerfile.mysql
@@ -1,0 +1,11 @@
+FROM mysql:8
+
+COPY ./sql/init-*.sql /docker-entrypoint-initdb.d
+
+ENV TZ=Asia/Shanghai
+ENV LANG=C.UTF-8
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=3s --retries=3 \
+  CMD mysqladmin ping -h localhost -u root --password=${MYSQL_ROOT_PASSWORD} || exit 1
+
+CMD ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci", "--lower-case-table-names=1"]

--- a/docker-multiarch/Dockerfile.service
+++ b/docker-multiarch/Dockerfile.service
@@ -1,0 +1,13 @@
+FROM amazoncorretto:17-alpine
+
+WORKDIR /app
+
+ENV TZ=Asia/Shanghai
+
+ARG JAR_FILE=orion-visor-launch/target/orion-visor-launch.jar
+COPY ${JAR_FILE} /app/app.jar
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=5 --start-period=10s \
+  CMD wget -T5 -qO- http://127.0.0.1:9200/orion-visor/api/server/bootstrap/health | grep ok || exit 1
+
+CMD ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]

--- a/docker-multiarch/Dockerfile.ui
+++ b/docker-multiarch/Dockerfile.ui
@@ -1,0 +1,6 @@
+FROM caddy:2-alpine
+
+ENV CADDY_TRUSTED_PROXIES=''
+
+COPY docker-multiarch/Caddyfile /etc/caddy/Caddyfile
+COPY orion-visor-ui/dist /usr/share/caddy


### PR DESCRIPTION
🐳 多架构 Docker 镜像

**这个PR的镜像想法和原本项目的思路可能完全不一样**，作者考虑下是否接受PR吧。这一部分可能个人理解不同。

- 之前的镜像把NGINX(前端资源)内置在了`orion-visor-service`镜像内，Java应用被放到后台运行(`&`)，如果Java应用崩溃，容器不会知道。PR单独添加了一个`ui`服务来提供前端资源(+接口代理)。
- MySQL的容器和之前也有不同，没用使用`my.cnf`文件，把需要的配置参数直接给 `mysqld`
- compose中的adminer和Redis没有使用aliyuncs的镜像。

------

另一部分是GitHub Actions 工作流的部分。`.github/workflows/docker.yaml`	

- 推送后会自动构建镜像推送到`ghcr.io`的镜像仓库。如果增加推送其他镜像仓库，增加一个`login-action`的步骤，并且在`meta`步骤的`images`部分加一行。比如

  ```yaml
      steps:
        - name: Login to Docker Hub
          uses: docker/login-action@v2
          with:
            username: ${{ secrets.DOCKERHUB_USERNAME }}
            password: ${{ secrets.DOCKERHUB_TOKEN }}
        - name: 🏷️ 准备 Docker 镜像元数据
          id: meta
          uses: docker/metadata-action@v5
          with:
            images: |
              ghcr.io/${{ github.repository }}-service
              name/app-service
            tags: ${{ env.metadata-action-tags }}
  ```

- 构建的tag分3种情况

  1. 如git推送`main`分支，镜像的tag是`:main`
  2. 如git推送`v1.2.3`的tag，镜像的tag是`1.2.3` `1.2` `1`加一个`latest`
  3. 如git推送`v2.0.8-rc1`的tag，镜像的tag是`2.0.8-rc1`

- `.github/settings.xml`文件是用来给`mvn`使用的，因为Actions的runner的机器都在国外，目的是给mvn构建的时候使用Maven官方仓库

------

